### PR TITLE
Fix LaTeX compile warnings in week-8 project

### DIFF
--- a/modules/week-8/project/2025a.tex
+++ b/modules/week-8/project/2025a.tex
@@ -129,7 +129,7 @@ Whenever a reviewer in \(R\) needs to access the database, they must
 authenticate themselves to the server which then decrypts the key~\(\KCR\) to 
 decrypt the video material by camera~\(C\).
 
-\subsection{Encrypting video for \(R\)}
+\subsection{Encrypting video for \texorpdfstring{\(R\)}{R}}
 
 \begin{exercise}
   What algorithm should we use to encrypt the video material?
@@ -239,7 +239,7 @@ The camera must therefore ratchet to a fresh key and IV for every new
 recording, and the ratchet state must be stored in non-volatile memory;
 otherwise the camera would reuse an old key--IV pair after a power cycle.
 
-\subsection{Uploading data to \(R\)}
+\subsection{Uploading data to \texorpdfstring{\(R\)}{R}}
 
 \begin{exercise}
   How should we get the encrypted video material from the camera~\(C\) to the 

--- a/modules/week-8/project/preamble.tex
+++ b/modules/week-8/project/preamble.tex
@@ -1,4 +1,3 @@
-\usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 \usepackage[swedish,british]{babel}
 
@@ -27,9 +26,8 @@
 %\usepackage{newclude}
 \usepackage{import}
 
-\usepackage[strict]{csquotes}
-\usepackage[single]{acro}
-\acsetup{cite/cmd=\autocite}
+\usepackage{acro}
+\acsetup{single, cite/cmd=\autocite}
 
 \usepackage{subcaption}
 
@@ -40,6 +38,9 @@
 
 \usepackage{minted}
 \setminted{autogobble,linenos}
+
+% Load csquotes after minted (which pulls in fvextra) per fvextra's request.
+\usepackage[strict]{csquotes}
 
 \usepackage{pythontex}
 \setpythontexoutputdir{.}
@@ -59,7 +60,7 @@
 \tikzset{/msc/instance distance=0.5\linewidth,
          /msc/draw frame=none}
 
-\usepackage[binary-units]{siunitx}
+\usepackage{siunitx}
 
 \usepackage[colorlinks]{hyperref}
 \usepackage{cleveref}


### PR DESCRIPTION
## Summary

Cleans up the warnings emitted when building `modules/week-8/project/notes.pdf` (`make all`). The build now produces only benign/informational messages (PythonTeX `listing` notice, csquotes strict-mode info) plus the British `translations` warnings (expected — the English version is what's used).

## Changes

- **`preamble.tex`**
  - Drop `\usepackage[utf8]{inputenc}` — ignored under XeTeX.
  - Move acro's `single` into `\acsetup{single, ...}` — no longer a load-time option in acro v3.
  - Drop siunitx's removed `binary-units` option (binary units are always available in siunitx v3; unused here anyway).
  - Load `csquotes` after `minted` so fvextra's load-order request is satisfied.
- **`2025a.tex`** — wrap `\(R\)` in two subsection titles with `\texorpdfstring` so hyperref builds the PDF bookmarks without "math shift" warnings.
- **`didactic` submodule** — bumped to pick up the amsthm theoremstyle fix (`style=theorem`/`proof` → built-in `plain`/`remark`), which silences the `Unknown theoremstyle` warnings.

## Verification

```bash
cd modules/week-8/project
make -C ../../../didactic didactic.sty
make clean && make all
grep -iE "inputenc package ignored|Unknown option .single|binary-units|csquotes should be loaded after fvextra|Token not allowed in a PDF string|Unknown theoremstyle" ltxobj/notes.log
```

`make all` exits 0 and the grep returns no matches. `notes.pdf` renders identically; the two 2025a bookmarks now read "Encrypting video for R" / "Uploading data to R".

> Note: the `didactic` submodule fix is pushed to `dbosk/didactic` `master` (`4606aa3`); this PR bumps the pointer to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)